### PR TITLE
feat: handle tapbacks and threaded replies for TEXT messages

### DIFF
--- a/mqttbridge/mqtt.py
+++ b/mqttbridge/mqtt.py
@@ -387,7 +387,24 @@ class MqttBridge(commands.Cog):
                     await self.check_claim_code(mp)
                     return
             
-                await self.send_to_discord(mp, se, message_text)
+                reply_id = getattr(mp.decoded, 'reply_id', 0)
+                emoji_flag = getattr(mp.decoded, 'emoji', 0)
+
+                discord_msg_id = None
+                if reply_id > 0:
+                    with self.get_db() as conn:
+                        c = conn.cursor()
+                        c.execute("SELECT discord_message_id FROM message_history WHERE message_id = ?", (reply_id,))
+                        result = c.fetchone()
+                        if result and result[0]:
+                            discord_msg_id = result[0]
+
+                if reply_id > 0 and emoji_flag != 0 and discord_msg_id:
+                    # Emoji Reaction (Tapback)
+                    await self.append_reaction_to_discord(mp, se, message_text, discord_msg_id)
+                else:
+                    # Threaded Reply or Standard Message
+                    await self.send_to_discord(mp, se, message_text, reply_to_discord_id=discord_msg_id if reply_id > 0 and emoji_flag == 0 else None)
 
             if mp.decoded.portnum == portnums_pb2.NODEINFO_APP:
                 try:
@@ -635,7 +652,7 @@ class MqttBridge(commands.Cog):
         except Exception as e:
             print(f"Error saving node to database: {str(e)}")
 
-    async def send_to_discord(self, mp, se, message_text):
+    async def send_to_discord(self, mp, se, message_text, reply_to_discord_id=None):
         """Send a decoded Meshtastic message to the configured Discord channel"""
         try:
             # Process channel information
@@ -728,10 +745,19 @@ class MqttBridge(commands.Cog):
                 
             # Send to Discord
             if self.messages_channel:
-                if "owner" in node_info and node_info["owner"] and node_info["owner"]["notifications"]:
-                    message = await self.messages_channel.send(f"<@{node_info['owner']['discord_id']}>", embed=embed)
+                reference = None
+                if reply_to_discord_id:
+                    try:
+                        reference = await self.messages_channel.fetch_message(reply_to_discord_id)
+                    except discord.NotFound:
+                        pass
+                
+                content = f"<@{node_info['owner']['discord_id']}>" if "owner" in node_info and node_info["owner"] and node_info["owner"]["notifications"] else None
+
+                if reference:
+                    message = await self.messages_channel.send(content=content, embed=embed, reference=reference)
                 else:
-                    message = await self.messages_channel.send(embed=embed)
+                    message = await self.messages_channel.send(content=content, embed=embed)
 
                 with self.get_db() as conn:
                     c = conn.cursor()
@@ -749,6 +775,57 @@ class MqttBridge(commands.Cog):
             print(f"Error formatting text message: {e}")
             import traceback
             print(traceback.format_exc())
+
+    async def append_reaction_to_discord(self, mp, se, message_text, discord_msg_id):
+        """Append an emoji reaction to the original Discord message's embed"""
+        try:
+            if not self.messages_channel:
+                return
+
+            try:
+                original_msg = await self.messages_channel.fetch_message(discord_msg_id)
+            except discord.NotFound:
+                return
+
+            if not original_msg.embeds:
+                return
+            
+            embed = original_msg.embeds[0]
+
+            # Get sender info
+            sender_int = getattr(mp, "from") if hasattr(mp, "from") else 0
+            sender_id = format(sender_int, '08x')
+
+            node_name = f"!{sender_id}"
+            
+            with self.get_db() as conn:
+                c = conn.cursor()
+                c.execute("SELECT long_name FROM nodes WHERE node_id = ?", (str(sender_int),))
+                node_row = c.fetchone()
+                if node_row and node_row[0]:
+                    node_name = node_row[0]
+
+            reaction_str = f"{message_text} - {node_name} (!{sender_id})"
+
+            # Find existing Reactions field
+            reactions_idx = -1
+            for i, field in enumerate(embed.fields):
+                if field.name == "Reactions":
+                    reactions_idx = i
+                    break
+            
+            if reactions_idx >= 0:
+                # Append to existing
+                current_value = embed.fields[reactions_idx].value
+                embed.set_field_at(reactions_idx, name="Reactions", value=f"{current_value}\n{reaction_str}", inline=False)
+            else:
+                # Add new field
+                embed.add_field(name="Reactions", value=reaction_str, inline=False)
+                
+            await original_msg.edit(embed=embed)
+            
+        except Exception as e:
+            print(f"Error appending reaction to Discord: {e}")
 
     async def process_telemetry(self, mp):
         """Process telemetry information and save it to the database"""

--- a/mqttbridge/mqtt.py
+++ b/mqttbridge/mqtt.py
@@ -401,7 +401,7 @@ class MqttBridge(commands.Cog):
 
                 if reply_id > 0 and emoji_flag != 0 and discord_msg_id:
                     # Emoji Reaction (Tapback)
-                    await self.append_reaction_to_discord(mp, se, message_text, discord_msg_id)
+                    await self.append_reaction_to_discord(mp, message_text, discord_msg_id)
                 else:
                     # Threaded Reply or Standard Message
                     await self.send_to_discord(mp, se, message_text, reply_to_discord_id=discord_msg_id if reply_id > 0 and emoji_flag == 0 else None)
@@ -749,7 +749,7 @@ class MqttBridge(commands.Cog):
                 if reply_to_discord_id:
                     try:
                         reference = await self.messages_channel.fetch_message(reply_to_discord_id)
-                    except discord.NotFound:
+                    except (discord.NotFound, discord.HTTPException):
                         pass
                 
                 content = f"<@{node_info['owner']['discord_id']}>" if "owner" in node_info and node_info["owner"] and node_info["owner"]["notifications"] else None
@@ -776,7 +776,7 @@ class MqttBridge(commands.Cog):
             import traceback
             print(traceback.format_exc())
 
-    async def append_reaction_to_discord(self, mp, se, message_text, discord_msg_id):
+    async def append_reaction_to_discord(self, mp, message_text, discord_msg_id):
         """Append an emoji reaction to the original Discord message's embed"""
         try:
             if not self.messages_channel:
@@ -784,7 +784,7 @@ class MqttBridge(commands.Cog):
 
             try:
                 original_msg = await self.messages_channel.fetch_message(discord_msg_id)
-            except discord.NotFound:
+            except (discord.NotFound, discord.HTTPException):
                 return
 
             if not original_msg.embeds:
@@ -814,12 +814,19 @@ class MqttBridge(commands.Cog):
                     reactions_idx = i
                     break
             
+            REACTIONS_FIELD_LIMIT = 1024
+
             if reactions_idx >= 0:
                 # Append to existing
                 current_value = embed.fields[reactions_idx].value
-                embed.set_field_at(reactions_idx, name="Reactions", value=f"{current_value}\n{reaction_str}", inline=False)
+                new_value = f"{current_value}\n{reaction_str}"
+                if len(new_value) > REACTIONS_FIELD_LIMIT:
+                    new_value = new_value[:REACTIONS_FIELD_LIMIT - 3] + "..."
+                embed.set_field_at(reactions_idx, name="Reactions", value=new_value, inline=False)
             else:
                 # Add new field
+                if len(reaction_str) > REACTIONS_FIELD_LIMIT:
+                    reaction_str = reaction_str[:REACTIONS_FIELD_LIMIT - 3] + "..."
                 embed.add_field(name="Reactions", value=reaction_str, inline=False)
                 
             await original_msg.edit(embed=embed)

--- a/mqttbridge/mqtt.py
+++ b/mqttbridge/mqtt.py
@@ -800,12 +800,13 @@ class MqttBridge(commands.Cog):
             
             with self.get_db() as conn:
                 c = conn.cursor()
-                c.execute("SELECT long_name FROM nodes WHERE node_id = ?", (str(sender_int),))
+                c.execute("SELECT short_name FROM nodes WHERE node_id = ?", (str(sender_int),))
                 node_row = c.fetchone()
                 if node_row and node_row[0]:
                     node_name = node_row[0]
 
-            reaction_str = f"{message_text} - {node_name} (!{sender_id})"
+            settings = await self.config.all()
+            reaction_str = f"{message_text} - [{node_name}]({settings['meshview_domain']}/packet/{mp.id})"
 
             # Find existing Reactions field
             reactions_idx = -1


### PR DESCRIPTION
# Reactions and Threaded Replies Implementation

The `mqttbridge` cog has been updated to better handle Meshtastic's threaded replies and emoji tapback reactions in Discord.

## Changes Made

### 1. Packet Processing Updates
In `mqtt.py`, the `process_mqtt_message` function was updated to evaluate two fields in the `TEXT_MESSAGE_APP` payload:
- `reply_id`: The ID of the message being replied to or reacted to.
- `emoji`: A flag that indicates the packet is an emoji tapback rather than a standard text message.

### 2. Threaded Replies
If a text packet contains a `reply_id` but *no* `emoji` flag, it is treated as a threaded reply.
- We perform a lookup in the local SQLite `message_history` table to find the corresponding `discord_message_id`.
- The `send_to_discord` method now accepts a `reply_to_discord_id` argument.
- We utilize Discord's native `reference` parameter when sending the message (`await channel.send(..., reference=msg)`), visually linking the reply to the original message in the Discord client.

### 3. Emoji Tapback Reactions
If a text packet contains both a `reply_id` and the `emoji` flag, it is treated as a tapback reaction.
- A new method, `append_reaction_to_discord`, was added to handle these.
- Instead of creating a new message, we fetch the original Discord message embed and modify it.
- We add (or append to) a `Reactions:` field in the embed, detailing the emoji and the specific node that reacted (e.g., `👍 - Bob (!abcd1234)`).
- We still save the packet to the `message_history` table to ensure that deduplication works, but we skip sending a separate Discord message to reduce channel noise.

## Validation
To test these changes:
1. Have a node send a normal broadcast text message.
2. Have another node "reply" to that message in the app. Verify it posts as a Discord reply.
3. Have a node send an emoji tapback reaction to the message. Verify the bot edits the original Discord message's embed with the reaction, rather than posting a new message.
