### PR TITLE
Fix Embed Edit, include src and dest, include snr

### DIFF
--- a/mqttbridge/mqtt.py
+++ b/mqttbridge/mqtt.py
@@ -1249,7 +1249,6 @@ class MqttBridge(commands.Cog):
                 
                 # Parse RouteDiscovery
                 route_discovery = mesh_pb2.RouteDiscovery()
-                route_names = []
                 try:
                     route_discovery.ParseFromString(mp.decoded.payload)
                     with self.get_db() as conn:
@@ -1264,24 +1263,34 @@ class MqttBridge(commands.Cog):
                                 return node_row[1]
                             return f"!{format(n_id, '08x')}"
 
-                        # Add origin (the node that sent the original trace request)
                         trace_origin = getattr(mp, "to", 0)
-                        if trace_origin:
-                            route_names.append(get_node_name(trace_origin))
-
-                        # Add intermediaries
-                        for hop_num in route_discovery.route:
-                            route_names.append(get_node_name(hop_num))
-                            
-                        # Add destination (the node that replied to the trace)
                         trace_dest = getattr(mp, "from", 0)
+                        
+                        # Get nodes in order
+                        nodes_in_order = []
+                        if trace_origin:
+                            nodes_in_order.append(get_node_name(trace_origin))
+                        for hop_num in route_discovery.route:
+                            nodes_in_order.append(get_node_name(hop_num))
                         if trace_dest:
-                            route_names.append(get_node_name(trace_dest))
+                            nodes_in_order.append(get_node_name(trace_dest))
+
+                        # Check if we have matching SNR data
+                        snrs = route_discovery.snr_towards
+                        
+                        if len(snrs) == len(route_discovery.route) + 1 and len(nodes_in_order) >= 2:
+                            # Format with SNR: Node1 --(snr)→ Node2
+                            route_parts = [nodes_in_order[0]]
+                            for i, snr in enumerate(snrs):
+                                route_parts.append(f"--({snr})→ {nodes_in_order[i+1]}")
+                            route_display = " ".join(route_parts)
+                        else:
+                            # Fallback without SNR
+                            route_display = " → ".join(nodes_in_order) if nodes_in_order else "Unknown"
 
                 except Exception as e:
                     print(f"Error parsing RouteDiscovery: {e}")
-
-                route_display = " → ".join(route_names) if route_names else "Unknown"
+                    route_display = "Unknown"
 
                 if discord_msg_id and self.traceroute_channel:
                     try:

--- a/mqttbridge/mqtt.py
+++ b/mqttbridge/mqtt.py
@@ -1254,16 +1254,30 @@ class MqttBridge(commands.Cog):
                     route_discovery.ParseFromString(mp.decoded.payload)
                     with self.get_db() as conn:
                         c = conn.cursor()
-                        for hop_num in route_discovery.route:
-                            hop_str = str(hop_num)
-                            c.execute("SELECT short_name, node_id_hex FROM nodes WHERE node_id = ?", (hop_str,))
+                        
+                        def get_node_name(n_id):
+                            c.execute("SELECT short_name, node_id_hex FROM nodes WHERE node_id = ?", (str(n_id),))
                             node_row = c.fetchone()
                             if node_row and node_row[0]:
-                                route_names.append(node_row[0])
+                                return node_row[0]
                             elif node_row and node_row[1]:
-                                route_names.append(node_row[1])
-                            else:
-                                route_names.append(f"!{format(hop_num, '08x')}")
+                                return node_row[1]
+                            return f"!{format(n_id, '08x')}"
+
+                        # Add origin (the node that sent the original trace request)
+                        trace_origin = getattr(mp, "to", 0)
+                        if trace_origin:
+                            route_names.append(get_node_name(trace_origin))
+
+                        # Add intermediaries
+                        for hop_num in route_discovery.route:
+                            route_names.append(get_node_name(hop_num))
+                            
+                        # Add destination (the node that replied to the trace)
+                        trace_dest = getattr(mp, "from", 0)
+                        if trace_dest:
+                            route_names.append(get_node_name(trace_dest))
+
                 except Exception as e:
                     print(f"Error parsing RouteDiscovery: {e}")
 
@@ -1273,8 +1287,8 @@ class MqttBridge(commands.Cog):
                     try:
                         original_msg = await self.traceroute_channel.fetch_message(discord_msg_id)
                         if original_msg.embeds:
-                            # Create a new embed from the original to ensure safe editing
-                            new_embed = discord.Embed.from_dict(original_msg.embeds[0].to_dict())
+                            # Create a copy of the embed to ensure safe editing
+                            new_embed = original_msg.embeds[0].copy()
                             
                             # Update Description
                             desc = new_embed.description
@@ -1284,12 +1298,18 @@ class MqttBridge(commands.Cog):
                                 desc = "Direction: REPLY (Complete)"
                             new_embed.description = desc
                             
-                            new_embed.add_field(name="Route Taken", value=route_display, inline=False)
+                            # Update or add the "Route Taken" field
+                            route_field_index = next((index for (index, field) in enumerate(new_embed.fields) if field.name == "Route Taken"), None)
+                            if route_field_index is not None:
+                                new_embed.set_field_at(route_field_index, name="Route Taken", value=route_display, inline=False)
+                            else:
+                                new_embed.add_field(name="Route Taken", value=route_display, inline=False)
+
                             await original_msg.edit(embed=new_embed)
                             # Flag that we successfully edited the message
                         else:
                             discord_msg_id = None # Fallback to new message
-                    except (discord.NotFound, discord.HTTPException) as e:
+                    except Exception as e:
                         print(f"Error editing original traceroute message: {e}")
                         # Fallback if message not found or edit fails
                         discord_msg_id = None


### PR DESCRIPTION
### Description
This PR addresses issues with traceroute embeds failing to edit or append when replies are received, and greatly enhances the information displayed in the route path.

### Changes
* **Fix Embed Edit Crash:** Replaced `discord.Embed.from_dict()` with a much safer `.copy()` method when duplicating the original embed. This prevents `TypeError` crashes that were occurring during payload conversions. Additionally, catching a generic `Exception` ensures the bot will always gracefully fall back to posting a new message if the edit fails for any reason.
* **Include Source and Destination in Route:** The `RouteDiscovery` payload only tracks intermediary nodes. Added logic to correctly prepend the origin and append the destination to the traceroute path so the full route is visible.
* **Include SNR in Route Display:** Extracted the `snr_towards` array from the `RouteDiscovery` payload. If the SNR data matches the forward path, the route is now formatted to show the signal-to-noise ratio at each hop (e.g., `NOD1 --(-2.5)→ NOD2 --(3.2)→ NOD3`).

### Testing
- Verify that traceroute replies successfully edit existing message embeds or post new ones.
- Verify that the source and destination are properly appended to the displayed path.
- Verify that the SNR parses successfully when provided by the node hardware.